### PR TITLE
Fixing numeric has_children parsing

### DIFF
--- a/DanbooruDownloader3/DAO/DanbooruPostDao.cs
+++ b/DanbooruDownloader3/DAO/DanbooruPostDao.cs
@@ -280,7 +280,7 @@ namespace DanbooruDownloader3.DAO
                     case "score": post.Score = reader.Value; break;
                     case "rating": post.Rating = reader.Value; break;
                     case "status": post.Status = reader.Value; break;
-                    case "has_children": post.HasChildren = Boolean.Parse(reader.Value); break;
+                    case "has_children": post.HasChildren = Convert.ToBoolean(Convert.ToInt32(reader.Value)); break;
                     case "created_at":
                         post.CreatedAt = reader.Value;
                         post.CreatedAtDateTime = ParseDateTime(post.CreatedAt, Option.Provider);


### PR DESCRIPTION
Since `Boolean.Parse()` only accepts `"True"` and `"False"` as values, the `has_children` value in the `<post>` tags broke on numeric string values like `"1"`. Using an int/bool parser combination fixes it for numeric values.

If values like "true" are used in some instances, this code would need to be modified to handle both cases, but it should work for any numeric values.