### PR TITLE
Adding booru.org compatibility

### DIFF
--- a/DanbooruDownloader3/Engine/GelbooruHtmlParser.cs
+++ b/DanbooruDownloader3/Engine/GelbooruHtmlParser.cs
@@ -58,6 +58,12 @@ namespace DanbooruDownloader3.Engine
                         break;
                     }
                 }
+                
+                // Some Gelbooru sites (*.booru.org) serve full resolution in the img tag
+                if (file_url == "")
+                {
+                    file_url = sample_url;
+                }
             }
 
             post.FileUrl = file_url;
@@ -68,15 +74,19 @@ namespace DanbooruDownloader3.Engine
             // parse datetime
             // TODO: untested
             var statsLIs = doc.DocumentNode.SelectNodes("//div[@id='stats']//li");
-            foreach (var item in statsLIs)
+            if (statsLIs != null)
             {
-                if (item.InnerHtml.StartsWith("Posted: "))
+                foreach (var item in statsLIs)
                 {
-                    post.CreatedAt = System.Text.RegularExpressions.Regex.Match(item.InnerHtml, "Posted: (.*)<").Value;
-                    post.CreatedAtDateTime = DanbooruPostDao.ParseDateTime(post.CreatedAt, post.Provider);
-                    break;
+                    if (item.InnerHtml.StartsWith("Posted: "))
+                    {
+                        post.CreatedAt = System.Text.RegularExpressions.Regex.Match(item.InnerHtml, "Posted: (.*)<").Value;
+                        post.CreatedAtDateTime = DanbooruPostDao.ParseDateTime(post.CreatedAt, post.Provider);
+                        break;
+                    }
                 }
             }
+
             return post;
         }
 


### PR DESCRIPTION
This makes some minor changes to the GelbooruHtmlParser to fix downloading from *.booru.org sites, and likely fixes issues with other Gelbooru sites as well.

For example, this new provider works well with these changes:

```xml
  <DanbooruProvider>
    <Name>the-collection.booru.org</Name>
    <DefaultLimit>20</DefaultLimit>
    <HardLimit>1000</HardLimit>
    <Preferred>Html</Preferred>
    <QueryStringXml />
    <QueryStringJson />
    <QueryStringHtml>/index.php?page=post&amp;s=list&amp;%_query%</QueryStringHtml>
    <Url>https://the-collection.booru.org</Url>
    <UserName />
    <Password />
    <LoginType>Anonymous</LoginType>
    <PasswordSalt />
    <PasswordHash />
    <BoardType>Gelbooru</BoardType>
    <TagDownloadUseLoop>true</TagDownloadUseLoop>
    <DateTimeFormat>yyyy-MM-dd HH:mm:ss</DateTimeFormat>
  </DanbooruProvider>
```

The datetime parser should be fixable to work with those sites too, I'll look into that next.