### PR TITLE
Fixed fail to build due to manual copy commands, removed manual <PreBuildEvent>xcopy

### DIFF
--- a/DanbooruDBProvider/DanbooruDBProvider.csproj
+++ b/DanbooruDBProvider/DanbooruDBProvider.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,8 +36,8 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.SQLite">
-      <HintPath>..\packages\System.Data.SQLite.Core.1.0.113.1\lib\net46\System.Data.SQLite.dll</HintPath>
+    <Reference Include="System.Data.SQLite, Version=1.0.115.5, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\lib\net46\System.Data.SQLite.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -49,13 +51,19 @@
     <Compile Include="SQLiteProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
-  <PropertyGroup>
-    <PreBuildEvent>xcopy /Y "$(SolutionDir)packages\System.Data.SQLite.Core.1.0.113.1\build\net46\x86\SQLite.Interop.dll" "$(TargetDir)x86\"
-xcopy /Y  "$(SolutionDir)packages\System.Data.SQLite.Core.1.0.113.1\build\net46\x64\SQLite.Interop.dll" "$(TargetDir)x64\"</PreBuildEvent>
-  </PropertyGroup>
+  <Import Project="..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets" Condition="Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets'))" />
+  </Target>
 </Project>

--- a/DanbooruDBProvider/packages.config
+++ b/DanbooruDBProvider/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="HtmlAgilityPack" version="1.4.6" targetFramework="net45" />
   <package id="Stub.System.Data.SQLite.Core.NetFramework" version="1.0.115.5" targetFramework="net481" />
   <package id="System.Data.SQLite.Core" version="1.0.115.5" targetFramework="net481" />
 </packages>

--- a/DanbooruDownloader3.test/DanbooruDownloader3.test.csproj
+++ b/DanbooruDownloader3.test/DanbooruDownloader3.test.csproj
@@ -15,6 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,6 +43,9 @@
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
+    <Reference Include="System.Data.SQLite, Version=1.0.115.5, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\lib\net46\System.Data.SQLite.dll</HintPath>
+    </Reference>
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
@@ -65,9 +70,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="DanbooruProviderList.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
     <Content Include="TestXml\danbooru.xml" />
     <Content Include="TestXml\gelbooru_post.htm" />
     <Content Include="TestXml\sankaku_nopaging.htm" />
@@ -80,6 +82,7 @@
     <Content Include="TestXml\yande.re.xml" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="TestXml\danbooru.json" />
     <None Include="TestXml\yande.re.json" />
   </ItemGroup>
@@ -88,10 +91,16 @@
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
-  <PropertyGroup>
-    <PreBuildEvent>xcopy /Y "$(SolutionDir)packages\System.Data.SQLite.Core.1.0.113.1\build\net46\x86\SQLite.Interop.dll" "$(TargetDir)x86\"
-xcopy /Y  "$(SolutionDir)packages\System.Data.SQLite.Core.1.0.113.1\build\net46\x64\SQLite.Interop.dll" "$(TargetDir)x64\"</PreBuildEvent>
-  </PropertyGroup>
+  <Target Name="CopyTextFiles" AfterTargets="Build">
+    <Copy SourceFiles="$(SolutionDir)\DanbooruProviderList.xml" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" ContinueOnError="true" />
+  </Target>
+  <Import Project="..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets" Condition="Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/DanbooruDownloader3.test/packages.config
+++ b/DanbooruDownloader3.test/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="HtmlAgilityPack" version="1.4.6" targetFramework="net45" />
   <package id="Stub.System.Data.SQLite.Core.NetFramework" version="1.0.115.5" targetFramework="net481" />
   <package id="System.Data.SQLite.Core" version="1.0.115.5" targetFramework="net481" />
 </packages>

--- a/DanbooruDownloader3/DanbooruDownloader3.csproj
+++ b/DanbooruDownloader3/DanbooruDownloader3.csproj
@@ -107,8 +107,8 @@
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.SQLite, Version=1.0.113.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SQLite.Core.1.0.113.1\lib\net46\System.Data.SQLite.dll</HintPath>
+    <Reference Include="System.Data.SQLite, Version=1.0.115.5, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\lib\net46\System.Data.SQLite.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
@@ -288,22 +288,19 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>copy $(SolutionDir)readme.txt $(TargetDir)readme.txt /Y
-copy $(SolutionDir)changelog.txt $(TargetDir)changelog.txt /Y
-copy $(SolutionDir)host_replacement.txt $(TargetDir)host_replacement.txt /Y</PostBuildEvent>
-  </PropertyGroup>
-  <Import Project="..\packages\System.Data.SQLite.Core.1.0.113.1\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.113.1\build\net46\System.Data.SQLite.Core.targets')" />
+  <Target Name="CopyTextFiles" AfterTargets="Build">
+    <ItemGroup>
+      <MyFiles Include="$(SolutionDir)\readme.txt;$(SolutionDir)\changelog.txt;$(SolutionDir)\host_replacement.txt" />
+    </ItemGroup>
+    <Copy SourceFiles="@(MyFiles)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" ContinueOnError="true" />
+  </Target>
+  <Import Project="..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets" Condition="Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.113.1\build\net46\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.113.1\build\net46\System.Data.SQLite.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.115.5\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets'))" />
   </Target>
-  <PropertyGroup>
-    <PreBuildEvent>xcopy /Y "$(SolutionDir)packages\System.Data.SQLite.Core.1.0.113.1\build\net46\x86\SQLite.Interop.dll" "$(TargetDir)x86\"
-xcopy /Y  "$(SolutionDir)packages\System.Data.SQLite.Core.1.0.113.1\build\net46\x64\SQLite.Interop.dll" "$(TargetDir)x64\"</PreBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Freshly check-out'ed project fails to build in VS2022:
```
Error		The command "
copy EDITED\DanbooruDownloader\readme.txt EDITED\DanbooruDownloader\DanbooruDownloader3\bin\Debug\readme.txt /Y
copy EDITED\DanbooruDownloader\changelog.txt EDITED\DanbooruDownloader\DanbooruDownloader3\bin\Debug\changelog.txt /Y
copy EDITED\DanbooruDownloader\host_replacement.txt 
EDITED\DanbooruDownloader\DanbooruDownloader3\bin\Debug\host_replacement.txt /Y" exited with code 1.			
Error		Could not copy the file EDITED\DanbooruDownloader\DanbooruDownloader3.test\DanbooruProviderList.xml" because it was not found.	DanbooruDownloader3.test			
```

Removed xcopy/copy build steps - you better specify copy steps in csproj terms - it handles errors better.

I'm not sure why you had to do `xcopy /Y "$(SolutionDir)packages\System.Data.SQLite.Core.1.0.113.1\build\net46\x86\SQLite.Interop.dll"`

if you use nuget, SQLite.Interop dlls are copied automatically. Changed to use nuget for SQLite.Core libs. Had to update SQLite.Core to 1.0.115.5 as 1.0.113.1 is no longer available.

Project now builds without any changes.